### PR TITLE
MAINT: remove extraneous version suffix in compiled libraries.

### DIFF
--- a/cmake/FindDO_Shakti.cmake
+++ b/cmake/FindDO_Shakti.cmake
@@ -51,11 +51,11 @@ foreach (COMPONENT ${DO_Shakti_USE_COMPONENTS})
 
   # Find compiled libraries.
   if (SHAKTI_USE_STATIC_LIBS)
-    set (_library_name "DO_Shakti_${COMPONENT}-${DO_Shakti_VERSION}-s")
-    set (_library_name_debug "DO_Shakti_${COMPONENT}-${DO_Shakti_VERSION}-sd")
+    set (_library_name "DO_Shakti_${COMPONENT}-s")
+    set (_library_name_debug "DO_Shakti_${COMPONENT}-sd")
   else ()
-    set (_library_name "DO_Shakti_${COMPONENT}-${DO_Shakti_VERSION}")
-    set (_library_name_debug "DO_Shakti_${COMPONENT}-${DO_Shakti_VERSION}-d")
+    set (_library_name "DO_Shakti_${COMPONENT}")
+    set (_library_name_debug "DO_Shakti_${COMPONENT}-d")
   endif ()
 
   find_library(DO_Shakti_${COMPONENT}_DEBUG_LIBRARIES

--- a/cmake/shakti_macros.cmake
+++ b/cmake/shakti_macros.cmake
@@ -172,7 +172,7 @@ macro (shakti_append_library _library_name
 
     # Form the compiled library output name.
     set(_library_output_basename
-        DO_Shakti_${_library_name}-${DO_Shakti_VERSION})
+        DO_Shakti_${_library_name})
     if (SHAKTI_BUILD_SHARED_LIBS)
       set (_library_output_name "${_library_output_basename}")
       set (_library_output_name_debug "${_library_output_basename}-d")


### PR DESCRIPTION
As the title says.