### PR TITLE
MAINT: fix version numbering in CMake scripts.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,11 +43,12 @@ find_package(DO_Sara COMPONENTS
 set(DO_Shakti_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(DO_Shakti_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/DO/Shakti)
 include(shakti_macros)
+shakti_dissect_version()
+
 include(shakti_configure_nvcc_compiler)
 include(shakti_configure_cxx_compiler)
 include(shakti_installation_settings)
 
-shakti_dissect_version()
 
 # ============================================================================ #
 # Build the following directories.


### PR DESCRIPTION
As the title says. Stupid mistake...