### PR TITLE
MAINT: workaround to find 'DO.Sara' library smartly.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,11 +25,13 @@ set(BUILD_SHARED_LIBS ${SHAKTI_BUILD_SHARED_LIBS})
 
 # ============================================================================ #
 # State the list of dependencies.
-if (WIN32)
-  set(DO_Sara_DIR "C:/Program Files/DO-Sara/include/DO/Sara")
-else ()
-  set(DO_Sara_DIR /usr/include/DO/Sara)
-endif ()
+find_path(
+  DO_Sara_DIR
+  NAMES cmake/FindDO_Sara.cmake
+  PATHS  "C:/Program Files/DO-Sara/include/DO/Sara"
+         /usr/local/include/DO/Sara
+         /usr/include/DO/Sara)
+
 list(APPEND CMAKE_MODULE_PATH
      ${DO_Sara_DIR}/cmake
      ${CMAKE_CURRENT_SOURCE_DIR}/cmake)


### PR DESCRIPTION
As the title says.