### PR TITLE
MAINT: clean CMake script.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,15 +25,7 @@ set(BUILD_SHARED_LIBS ${SHAKTI_BUILD_SHARED_LIBS})
 
 # ============================================================================ #
 # State the list of dependencies.
-find_path(
-  DO_Sara_DIR
-  NAMES cmake/FindDO_Sara.cmake
-  PATHS  "C:/Program Files/DO-Sara/include/DO/Sara"
-         /usr/local/include/DO/Sara
-         /usr/include/DO/Sara)
-
 list(APPEND CMAKE_MODULE_PATH
-     ${DO_Sara_DIR}/cmake
      ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 # Find third-party libraries.


### PR DESCRIPTION
Let's use CMAKE_PREFIX_PATH and project config CMake files instead.

We use the following guidelines here: https://cmake.org/Wiki/CMake/Tutorials/Packaging